### PR TITLE
Fix README import

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ export default App;
 
 ```tsx
 import React from "react";
-import MetaDataCard from "./src/MetaDataCard";
+import MetaDataCard from "@kteehan/photo-metadata-extractor";
 
 function App() {
   const handleMetaDataCallback = (metadata) => {


### PR DESCRIPTION
## Summary
- fix import path in README example for image URL

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781f5cbb708321a1c923e1fe95dc43