### PR TITLE
Fix MetaDataList position suffix test values

### DIFF
--- a/src/__tests__/MetaDataList.test.tsx
+++ b/src/__tests__/MetaDataList.test.tsx
@@ -15,7 +15,7 @@ describe("MetaDataList", () => {
       <MetaDataList
         metadata={metadata}
         showMetaData={true}
-        positionSuffix="left"
+        positionSuffix="top-left"
       />,
     );
     const metadataList = screen.getByTestId("metadata-list");
@@ -30,7 +30,7 @@ describe("MetaDataList", () => {
       <MetaDataList
         metadata={metadata}
         showMetaData={false}
-        positionSuffix="bottom"
+        positionSuffix="bottom-right"
       />,
     );
     const metadataList = screen.getByTestId("metadata-list");
@@ -45,7 +45,7 @@ describe("MetaDataList", () => {
       <MetaDataList
         metadata={metadata}
         showMetaData={true}
-        positionSuffix="left"
+        positionSuffix="bottom-left"
         onMouseLeave={() => {}}
       />,
     );
@@ -58,7 +58,7 @@ describe("MetaDataList", () => {
       <MetaDataList
         metadata={metadata}
         showMetaData={true}
-        positionSuffix="right"
+        positionSuffix="top-right"
       />,
     );
     const metadataItems = screen.getAllByRole("listitem");


### PR DESCRIPTION
## Summary
- update MetaDataList tests to use valid position suffix values

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687823dc1c508321aebc3284b4f43e01